### PR TITLE
Change a Chart Library

### DIFF
--- a/assets/js/chart.js
+++ b/assets/js/chart.js
@@ -1,16 +1,31 @@
-// Modify Chart.js Global Settings
-const configureChart = () => {
-  Chart.defaults.global.defaultFontColor = "#84919e";
-  Chart.defaults.global.defaultFontFamily = "'Roboto','Helvetica',sans-serif";
-  Chart.defaults.global.devicePixelRatio = 3;
-  Chart.defaults.global.responsive = false;
+const drawColumnChart = (id, source) => {
+  google.charts.load("current", { packages: ["corechart"] });
+  google.charts.setOnLoadCallback(drawChart);
+
+  function drawChart() {
+    const obj = JSON.parse(JSON.stringify(source));
+
+    const data = new google.visualization.DataTable();
+    for (let i = 0; i < obj.data.headers.length; i++) {
+      data.addColumn(obj.data.headers[i]["type"], obj.data.headers[i]["name"]);
+    }
+    data.addRows(obj.data.rows);
+
+    new google.visualization.ColumnChart(document.getElementById(id)).draw(
+      data,
+      obj.options
+    );
+
+    // Callback
+    setTimeout(function () {
+      moveToEnd(id);
+    });
+  }
 };
 
-configureChart();
-
-// Draw a Chart
-const drawChart = function (ID, DATA) {
-  const data = JSON.parse(JSON.stringify(DATA));
-  const ctx = document.getElementById(ID).getContext("2d");
-  const renderChart = new Chart(ctx, data);
+// Set the initial position of the horizontal scroll to the end.
+const moveToEnd = (id) => {
+  const target = document.getElementById(id);
+  const width = document.querySelector(`#${id} svg`).clientWidth;
+  target.parentElement.scrollLeft += width;
 };

--- a/assets/scss/screen/layouts.scss
+++ b/assets/scss/screen/layouts.scss
@@ -237,8 +237,7 @@ a {
     &__canvas {
         @include margin-inline(auto);
         block-size: 25rem;
-        display: block;
-        max-inline-size: none;
+        inline-size: max-content; // Google Charts で，グラフが狭幅（水平スクロールバーが表示されない位）の時にセンタリンク可能にする
     }
 }
 

--- a/data_updater/subway_passengers.py
+++ b/data_updater/subway_passengers.py
@@ -12,10 +12,7 @@ data = config['data'][0]
 with open(dst + data['raw']) as f:
     data_json = json.load(f)['datasets']
 
-labels = []
-time_0630_0730 = []
-time_0730_0930 = []
-time_0930_1030 = []
+list = []
 
 for i in data_json:
     # Fix Date Format
@@ -70,41 +67,76 @@ for i in data_json:
     date_left = date_left.strftime('%m-%d')
     date_right = date_right.strftime('%m-%d')
 
-    date = date_left + "~" + date_right
+    date = date_left + '~' + date_right
 
-    labels.append(date)
-    time_0630_0730.append(i['data'][0])
-    time_0730_0930.append(i['data'][1])
-    time_0930_1030.append(i['data'][2])
+    list.append([date, i['data'][0], i['data'][1], i['data'][2]])
 
 dict = {
-    'type': 'bar',
     'data': {
-            'labels': labels,
-            'datasets': [
-                {
-                    'label': '6:30~7:30',
-                    'data': time_0630_0730,
-                    'backgroundColor': '#c2d94c'
-                },
-                {
-                    'label': '7:30~9:30',
-                    'data': time_0730_0930,
-                    'backgroundColor': '#03af7a'
-                },
-                {
-                    'label': '9:30~10:30',
-                    'data': time_0930_1030,
-                    'backgroundColor': '#84dcb0'
-                }
-            ]
+        'headers': [
+            {'type': 'string', 'name': 'Durations'},
+            {'type': 'number', 'name': '6:30~7:30'},
+            {'type': 'number', 'name': '7:30~9:30'},
+            {'type': 'number', 'name': '9:30~10:30'}
+        ],
+        'rows': list,
     },
     'options': {
-        'scales': {
-            'yAxes': [
-                {'ticks': {'suggestedMax': 10, 'suggestedMin': 0, 'stepSize': 10}}
-            ]
-        }
+        'backgroundColor': {
+            'fill': 'none'
+        },
+        'chartArea': {
+            'bottom': 14 * 6,
+            'left': 14 * 4,
+            'right': 14 * 4,
+            'top': 14 * 2
+        },
+        'color': '#84919e',
+        'fontName': 'sans-serif',
+        'fontSize': 14,
+        'hAxes': [
+            {
+                'slantedText': True,
+                'slantedTextAngle': 45,
+                'textStyle': {'color': '#84919e'}
+            }
+        ],
+        'legend': {
+            'alignment': 'end',
+            'position': 'top',
+            'textStyle': {'color': '#84919e'}
+        },
+        'series': {
+            '0': {
+                'targetAxisIndex': 0
+            },
+            '1': {
+                'targetAxisIndex': 1
+            }
+        },
+        'vAxes': [
+            {
+                'baseline': 0,
+                'baselineColor': '#84919e',
+                'format': "#'%'",
+                'gridlines': {'color': '#84919e'},
+                'maxValue': 20,
+                'minorGridlines': {'color': 'none'},
+                'minValue': -100,
+                'textStyle': {'color': '#84919e'}
+            },
+            {
+                'baseline': 0,
+                'baselineColor': '#84919e',
+                'format': "#'%'",
+                'gridlines': {'color': '#84919e'},
+                'maxValue': 20,
+                'minorGridlines': {'color': 'none'},
+                'minValue': -100,
+                'textStyle': {'color': '#84919e'}
+            }
+        ],
+        'width': len(list) * 3 * 14
     }
 }
 

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -3,7 +3,7 @@
 
 {{ $js_chart := (resources.Get "js/chart.js").Content   }}
 {{ $js_list := (resources.Get "js/list.js").Content  }}
-{{ $js_lib_chart := "https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.9.4/Chart.min.js" }}
+{{ $js_lib_chart := "https://www.gstatic.com/charts/loader.js" }}
 {{ $js_lib_list := "https://cdnjs.cloudflare.com/ajax/libs/list.js/1.5.0/list.min.js" }}
 
 <!DOCTYPE html>
@@ -61,7 +61,7 @@
     </footer>
 
     {{/* Script Files */}}
-    {{/* Chart.js */}}
+    {{/* Google Charts */}}
     {{ if or (.HasShortcode "chart") (.IsHome) }}
       <script src='{{ $js_lib_chart | safeURL }}'></script>
       <script>

--- a/layouts/shortcodes/chart.html
+++ b/layouts/shortcodes/chart.html
@@ -1,25 +1,29 @@
 {{ $data_src := print "data/" (.Get "src") ".json" }}
 {{ $data_id := print "json_" (.Get "src") }}
-{{ $chart_id := print "chart-" (replace (.Get "src") "_" "-") }}
+{{ $canvas_id := print "chart-" (replace (.Get "src") "_" "-")}}
 
 <div class="data-chart">
-  <canvas
+  <div
     aria-label='{{ .Page.Title | title }}'
-    role="img"
     class="data-chart__canvas"
-    id='{{ $chart_id | safeHTMLAttr }}'
-  ></canvas>
+    id='{{ $canvas_id | safeHTMLAttr }}'
+  ></div>
 </div>
 
 <div class="scroll-message">
   {{- i18n "scroll_message" -}}
 </div>
 
-<script>
-  window.addEventListener("load", function () {
-    // readFile で強引に JSON を読み込ませる
-    const {{ $data_id | safeJS }} = {{ readFile $data_src | safeJS }};
-
-    drawChart('{{ $chart_id | safeJS }}', {{ $data_id | safeJS }});
-  });
-</script>
+{{/* print を使った煩雑なコードなのは VS Code のエラー防止のため */}}
+{{/*
+    window.addEventListener("load", function () {
+      const $data_id = (readFile $data_src | safeJS);
+      drawColumnChart('$canvas_id', $data_id);
+    });
+ */}}
+{{ print "<" "script" ">" | safeHTML }}
+{{ print "window.addEventListener('load', function () {" | safeHTML }}
+{{ print "const " $data_id " = " (readFile $data_src | safeJS) ";" | safeHTML }}
+{{ print "drawColumnChart('" $canvas_id "'," $data_id ");" | safeHTML }}
+{{ print "});" | safeHTML }}
+{{ print "<" "/script" ">" | safeHTML }}


### PR DESCRIPTION
<!--
  issue 番号なき PR は受け付けません。
  PRs without the issue ID would never be accepted.

  できるだけ簡潔に記述してください。
  Write as simply as you can.
-->

## 解決する issue / Resolved Issues

- Close #178

## 詳細 / Details

- Use Google Charts as a chart library instead of Chart.js
- Modified files related to the chart.
- Modified `./data_updater/subway_passengers.py`.

## スクリーンショット / Screenshots

### Before

![image](https://user-images.githubusercontent.com/46659204/100514400-c2171180-31b7-11eb-8ef9-600a09bf4648.png)

### After

![image](https://user-images.githubusercontent.com/46659204/100514413-d1965a80-31b7-11eb-80fe-2edd4ff5c137.png)
